### PR TITLE
Add interactive score entry screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,18 @@
   <title>Golf Scorecard Setup</title>
   <style>
     body { font-family: Arial, sans-serif; padding: 32px; background: #f9f9f9; }
-    .container { background: #fff; padding: 32px; border-radius: 12px; box-shadow: 0 0 10px #ddd; max-width: 400px; margin: auto; }
+    .container { background: #fff; padding: 32px; border-radius: 12px; box-shadow: 0 0 10px #ddd; max-width: 800px; margin: auto; }
     .section { margin-bottom: 24px; }
     label { font-weight: 500; }
     input[type="number"] { width: 60px; }
     .hidden { display: none; }
     button { padding: 10px 18px; border: none; border-radius: 5px; background: #2e7d32; color: #fff; cursor: pointer; }
     button:hover { background: #219150; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 16px; }
+    th, td { border: 1px solid #ccc; padding: 6px; text-align: center; }
+    th { background: #f0f0f0; }
+    .modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; }
+    .modal-content { background: #fff; padding: 20px; border-radius: 8px; }
   </style>
 </head>
 <body>
@@ -59,43 +64,50 @@
       });
     });
 
+    let holes = 0;
+    let playerCount = 0;
+    let coursePar = null;
+    let playerNames = [];
+    let scores = [];
+    let totals = [];
+    let currentHole = 1;
+    let currentPlayerIndex = 0;
+
     document.getElementById('nextBtn').addEventListener('click', function() {
       // Holes
-      let holes = document.querySelector('input[name="holes"]:checked');
-      if (!holes) { alert('Please select how many holes.'); return; }
-      if (holes.value === 'custom') {
-        holes = document.getElementById('customHoles').value;
-        if (!holes || holes < 1) { alert('Enter a valid number of holes.'); return; }
+      let h = document.querySelector('input[name="holes"]:checked');
+      if (!h) { alert('Please select how many holes.'); return; }
+      if (h.value === 'custom') {
+        h = document.getElementById('customHoles').value;
+        if (!h || h < 1) { alert('Enter a valid number of holes.'); return; }
       } else {
-        holes = parseInt(holes.value, 10);
+        h = parseInt(h.value, 10);
       }
 
       // Players
-      let players = document.querySelector('input[name="players"]:checked');
-      if (!players) { alert('Please select how many players.'); return; }
-      if (players.value === 'custom') {
-        players = document.getElementById('customPlayers').value;
-        if (!players || players < 1) { alert('Enter a valid number of players.'); return; }
+      let p = document.querySelector('input[name="players"]:checked');
+      if (!p) { alert('Please select how many players.'); return; }
+      if (p.value === 'custom') {
+        p = document.getElementById('customPlayers').value;
+        if (!p || p < 1) { alert('Enter a valid number of players.'); return; }
       } else {
-        players = parseInt(players.value, 10);
+        p = parseInt(p.value, 10);
       }
 
-      // Par (optional)
-      let par = document.getElementById('coursePar').value || null;
-
-      // For demo, log values. Replace this with your navigation to the next screen.
-      console.log('Holes:', holes);
-      console.log('Players:', players);
-      console.log('Course Par:', par);
+      holes = h;
+      playerCount = p;
+      coursePar = document.getElementById('coursePar').value;
+      if (coursePar) coursePar = parseInt(coursePar, 10);
+      else coursePar = null;
 
       // Move to player name entry screen
-      showPlayerNameInput(players);
+      showPlayerNameInput();
     });
 
-    function showPlayerNameInput(players) {
+    function showPlayerNameInput() {
       const container = document.getElementById('setup-screen');
       let html = '<h2>Enter Player Names</h2>';
-      for (let i = 1; i <= players; i++) {
+      for (let i = 1; i <= playerCount; i++) {
         html += `\n        <div class="section">\n          <label for="player${i}">Player ${i}:</label><br>\n          <input type="text" id="player${i}" placeholder="Player ${i} name">\n        </div>`;
       }
       html += '\n      <button id="playersNextBtn">Next</button>';
@@ -103,14 +115,105 @@
 
       document.getElementById('playersNextBtn').addEventListener('click', function() {
         const names = [];
-        for (let i = 1; i <= players; i++) {
+        for (let i = 1; i <= playerCount; i++) {
           const name = document.getElementById('player' + i).value.trim();
           if (!name) { alert('Please enter all player names.'); return; }
           names.push(name);
         }
-        console.log('Player Names:', names);
-        container.innerHTML = `<h2>Names Recorded</h2>\n          <p>${names.join(', ')}</p>\n          <p>(Proceed to next step...)</p>`;
+        playerNames = names;
+        startScorecard();
       });
+    }
+
+    function startScorecard() {
+      scores = Array.from({ length: playerCount }, () => Array(holes).fill(null));
+      totals = Array(playerCount).fill(0);
+
+      const container = document.getElementById('setup-screen');
+      let html = '<h2>Scorecard</h2><table id="scoreTable"><thead><tr><th>Player</th>';
+      for (let i = 1; i <= holes; i++) { html += `<th>${i}</th>`; }
+      html += '<th>Total</th>';
+      if (coursePar) html += '<th>Vs Par</th>';
+      html += '</tr></thead><tbody>';
+      for (let p = 0; p < playerCount; p++) {
+        html += `<tr><td>${playerNames[p]}</td>`;
+        for (let h = 1; h <= holes; h++) {
+          html += `<td id="score-${p}-${h}"></td>`;
+        }
+        html += `<td id="total-${p}">0</td>`;
+        if (coursePar) html += `<td id="vs-${p}">E</td>`;
+        html += '</tr>';
+      }
+      html += '</tbody></table>';
+      html += `<button id="enterScoresBtn">Enter Scores for Hole 1</button>`;
+      html += '<div id="leaderboard"></div>';
+      html += `<div id="scoreModal" class="modal hidden"><div class="modal-content"><h3 id="modalTitle"></h3><input type="number" id="scoreInput" min="0"><button id="scoreSubmit">Save</button></div></div>`;
+      container.innerHTML = html;
+
+      document.getElementById('enterScoresBtn').addEventListener('click', openScoreEntry);
+      document.getElementById('scoreSubmit').addEventListener('click', saveScore);
+    }
+
+    function openScoreEntry() {
+      currentPlayerIndex = 0;
+      document.getElementById('scoreInput').value = '';
+      showModal();
+    }
+
+    function showModal() {
+      const modal = document.getElementById('scoreModal');
+      document.getElementById('modalTitle').innerText = `Enter score for ${playerNames[currentPlayerIndex]} - Hole ${currentHole}`;
+      modal.classList.remove('hidden');
+      document.getElementById('scoreInput').focus();
+    }
+
+    function formatDiff(diff) {
+      diff = Math.round(diff);
+      if (diff === 0) return 'E';
+      return diff > 0 ? '+' + diff : diff.toString();
+    }
+
+    function saveScore() {
+      const input = document.getElementById('scoreInput');
+      const val = parseInt(input.value, 10);
+      if (isNaN(val)) { alert('Enter a valid score'); return; }
+      scores[currentPlayerIndex][currentHole - 1] = val;
+      totals[currentPlayerIndex] += val;
+      document.getElementById(`score-${currentPlayerIndex}-${currentHole}`).innerText = val;
+      document.getElementById(`total-${currentPlayerIndex}`).innerText = totals[currentPlayerIndex];
+      if (coursePar) {
+        const parPerHole = coursePar / holes;
+        const diff = totals[currentPlayerIndex] - parPerHole * currentHole;
+        document.getElementById(`vs-${currentPlayerIndex}`).innerText = formatDiff(diff);
+      }
+      currentPlayerIndex++;
+      input.value = '';
+      if (currentPlayerIndex < playerCount) {
+        showModal();
+      } else {
+        document.getElementById('scoreModal').classList.add('hidden');
+        if (currentHole < holes) {
+          currentHole++;
+          document.getElementById('enterScoresBtn').innerText = `Enter Scores for Hole ${currentHole}`;
+        } else {
+          document.getElementById('enterScoresBtn').style.display = 'none';
+          showLeaderboard();
+        }
+      }
+    }
+
+    function showLeaderboard() {
+      const board = document.getElementById('leaderboard');
+      const arr = playerNames.map((name, idx) => ({ name, total: totals[idx] }));
+      arr.sort((a, b) => a.total - b.total);
+      let html = '<h2>Final Leaderboard</h2><ol>';
+      arr.forEach(p => {
+        let diffStr = '';
+        if (coursePar) diffStr = ` (${formatDiff(p.total - coursePar)})`;
+        html += `<li>${p.name}: ${p.total}${diffStr}</li>`;
+      });
+      html += '</ol>';
+      board.innerHTML = html;
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- expand styling for table and modal
- capture setup values and load player name screen
- build scorecard table with score entry modal
- track running totals and show final leaderboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871e64e8f408323a7ed82068d298261