### PR TITLE
Fix default flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,14 +223,7 @@
       board.innerHTML = html;
     }
 
-    // Display scorecard by default with example players
-    document.addEventListener('DOMContentLoaded', () => {
-      holes = 9;
-      playerCount = 4;
-      playerNames = Array.from({ length: playerCount }, (_, i) => `Player ${i + 1}`);
-      coursePar = null;
-      startScorecard();
-    });
+    // The scorecard starts after the setup and player name screens
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove demo screen on page load so setup and player entry screens appear first

## Testing
- `bash -lc 'git status --short'`

------
https://chatgpt.com/codex/tasks/task_e_6871f14f14c883239981d5c170b953c2