### PR TITLE
Add dynamic hole button to golf scorecard

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
     function startScorecard() {
       scores = Array.from({ length: playerCount }, () => Array(holes).fill(null));
       totals = Array(playerCount).fill(0);
+      currentHole = 1;
 
       const container = document.getElementById('setup-screen');
       let html = '<h2>Scorecard</h2><table id="scoreTable"><thead><tr><th>Player</th>';
@@ -146,16 +147,12 @@
       }
       html += '</tbody></table>';
       html += '<div id="holeButtons">';
-      for (let i = 1; i <= holes; i++) {
-        html += `<button class="holeBtn" data-hole="${i}">Enter Score for Hole ${i}</button> `;
-      }
+      html += '<button id="nextHoleBtn">Enter Score for Hole 1</button>';
       html += '</div>';
       html += '<div id="leaderboard"></div>';
       container.innerHTML = html;
 
-      document.querySelectorAll('.holeBtn').forEach(btn => {
-        btn.addEventListener('click', () => openScoreEntry(parseInt(btn.dataset.hole, 10)));
-      });
+      document.getElementById('nextHoleBtn').addEventListener('click', () => openScoreEntry(currentHole));
     }
 
     function openScoreEntry(hole) {
@@ -211,12 +208,13 @@
         showModal();
       } else {
         document.getElementById('scoreModal').classList.add('hidden');
-        const btn = document.querySelector(`button[data-hole="${currentHole}"]`);
-        if (btn) btn.disabled = true;
-        const allFilled = scores.every(row => row.every(s => s !== null));
-        if (allFilled) {
+        currentHole++;
+        if (currentHole > holes) {
           document.getElementById('holeButtons').style.display = 'none';
           showLeaderboard();
+        } else {
+          const btn = document.getElementById('nextHoleBtn');
+          if (btn) btn.textContent = `Enter Score for Hole ${currentHole}`;
         }
       }
     }


### PR DESCRIPTION
## Summary
- change setup to show a single button for entering hole scores
- update button text as holes are completed
- hide button and show leaderboard when round finished

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753c88a2e88323abe345f06d70d735